### PR TITLE
Added a -is flag to include strings

### DIFF
--- a/core/fuzzyCreator.py
+++ b/core/fuzzyCreator.py
@@ -72,7 +72,7 @@ class fuzzyCreator(object):
             raise e
 
 
-    def render(self, subfolder=True):
+    def render(self, subfolder=True, include_strings=False):
         if not self.outDir.exists():
             self.outDir.mkdir(parents=True)
 
@@ -80,6 +80,7 @@ class fuzzyCreator(object):
 
         outDir = self.outDir
         for model in self.models:
+            model.include_strings = include_strings
             if subfolder:
                 outDir = self.outDir / model.name
                 if not outDir.exists():
@@ -100,6 +101,7 @@ class fuzzyCreator(object):
 
         # Check if the model type has any common that should be copied as well
         for mt in model_types_added:
+            mt.include_strings = include_strings
             templ_dir = Path(__file__).parent / '..' / \
                              'templates' / folders[mt.type]
             common = (templ_dir / 'common').exists()

--- a/main.py
+++ b/main.py
@@ -30,6 +30,8 @@ if __name__ == '__main__':
                         help='disable the subfolder division')
     parser.add_argument('-d', '--output-dir', type=outputDir,
                         default='./output', help='output directory')
+    parser.add_argument('-is', '--include_strings', action="store_true",
+                        help='Include names in input and output (models require more memory)')
 
     args = parser.parse_args()
 
@@ -37,6 +39,6 @@ if __name__ == '__main__':
         with toml.open('r') as t:
             try:
                 fuzzyCreator(t.read(), args.output_dir).render(
-                    args.no_subforlder)
+                    args.no_subforlder, args.include_strings)
             except:
                 raise

--- a/templates/F-IND/common/findInput.h.j2
+++ b/templates/F-IND/common/findInput.h.j2
@@ -10,6 +10,8 @@ typedef struct {
 	uint_t nMF;					//!< Number of MF
 	dataType minValue;			//!< Minimum value of the FIND Input
 	dataType maxValue;			//!< Maximum value of the FIND Input
+	{% if model.include_strings %}    char *name;         //!< Input name{% endif %}
+
 } findInput;
 
 /*! INIT OF A FIND INPUT

--- a/templates/F-IND/common/findLogic.h.j2
+++ b/templates/F-IND/common/findLogic.h.j2
@@ -10,6 +10,8 @@ typedef struct {
 	squareduint_t two_to_ndim;
 	findInput *fInput;
 	findOutput *fOutput;
+	{% if model.include_strings %}    char *name; {% endif %}
+
 } findLogic;
 
 /*! CONSTRUCTOR OF THE FIND LOGIC FOR FIND SYSTEM

--- a/templates/F-IND/common/findOutput.h.j2
+++ b/templates/F-IND/common/findOutput.h.j2
@@ -9,6 +9,8 @@
 typedef struct {
 	memFunction *mf;	//!< List of the Member Functions
 	uint_t nMF;					//!< Number of MF
+	{% if model.include_strings %}   char *name;         //!< Output name{% endif %}
+
 } findOutput;
 
 /*! INIT OF A FIND OUTPUT

--- a/templates/F-IND/init.c.j2
+++ b/templates/F-IND/init.c.j2
@@ -44,8 +44,12 @@ static const dataType normalizedWeights[N_INPUT_{{ model.name }}][{{ model.getMa
 
 void initFindLogic_{{ model.name }}(findLogic *fl) {
 
+    {% if model.include_strings %}    fl->name = "{{ model.name }}"; {% endif %}
+
 	{% for vin in model.input_var %}
 	// Input variable: {{ vin.name }}
+
+    {% if model.include_strings %}fi[{{ loop.index0 }}].name = "{{ vin.name }}";{% endif %}
 
 	{% for mf in vin.membership_functions %}
 	createMemFunction(&(MF_{{ vin.name }}[{{ loop.index0 }}]), {{ mfDict.get(mf.type) }}, poi_{{ vin.name }}_{{ mf.name }});
@@ -61,6 +65,8 @@ void initFindLogic_{{ model.name }}(findLogic *fl) {
 
 	{% for vout in model.output_var %}
 	// Output variable: {{ vout.name }}
+
+    {% if model.include_strings %}fo.name = "{{ vout.name }}";{% endif %}
 
 	{% for mf in vout.membership_functions %}
 	createMemFunction(&(MF_{{ vout.name }}[{{ loop.index0 }}]), {{ mfDict.get(mf.type) }}, poi_{{ vout.name }}_{{ mf.name }});


### PR DESCRIPTION
In the previous implementation, strings were stripped to save memories
on constrained environments.
This is good, but there are scenarios for which strings are useful.
Therefore, a -is flag has been added, that includes the model name, the
input and the output variables names in the generated .c files.