### PR TITLE
Steps too small

### DIFF
--- a/core/Model.py
+++ b/core/Model.py
@@ -203,8 +203,8 @@ class ModelFIND(Model):
     def parseRules(self):
 
         # TODO: Decide how to give the step parameter as input
-        #step = 10000
-        step = 2
+        step = 10000
+        # step = 2
         self.computeVariables(step)
 
     def computeVariables(self, step):


### PR DESCRIPTION
I set the step to 10000 which is the default value in F-IND.
This is a more reasonable approximations for integrations, as 2
introduces way too much error.